### PR TITLE
fix: force WiFi disconnect before establishing a new

### DIFF
--- a/src/WiFiConnector.h
+++ b/src/WiFiConnector.h
@@ -54,6 +54,7 @@ class WiFiConnectorClass {
     bool connect(const String& ssid, const String& pass = emptyString) {
         if (ssid.length()) {
             _tryConnect = true;
+            WiFi.disconnect();
             WiFi.mode(WIFI_AP_STA);
             _startAP();
             WiFi.begin(ssid.c_str(), pass.c_str());


### PR DESCRIPTION
На ESP32, если попытка подключения не удалась или зависла, последующие вызовы WiFi.begin() с другим SSID могут завершиться неудачей или быть проигнорированы. Добавление WiFi.disconnect() сбрасывает внутренний конечный автомат Wi-Fi и позволяет успешно подключиться к новой сети.